### PR TITLE
Feature/64

### DIFF
--- a/fakes/SurveyEnvelope.php
+++ b/fakes/SurveyEnvelope.php
@@ -32,21 +32,24 @@ abstract class SurveyEnvelope implements Scalar
         /**
          * Element to be used in some context.
          * 
-         * @var X
+         * @phpstan-var X
+         * @var mixed
          */
         private mixed $subject,
 
         /**
          * Context for element.
          * 
-         * @var Closure(X): mixed
+         * @phpstan-var Closure(X): mixed
+         * @var Closure
          */
         private Closure $context,
 
         /**
          * way of combining element and context.
          * 
-         * @var Closure(X, Closure(X): mixed): Y
+         * @phpstan-var Closure(X, Closure(X): mixed): Y
+         * @var Closure
          */
         private Closure $usage
     ) {
@@ -55,7 +58,8 @@ abstract class SurveyEnvelope implements Scalar
     /**
      * Returns result of applying context to element.
      *
-     * @return Y
+     * @phpstan-return Y
+     * @return mixed
      */
     public final function value(): mixed
     {

--- a/tests/src/SavingIteratorTest.php
+++ b/tests/src/SavingIteratorTest.php
@@ -16,13 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass MaxGoryunov\SavingIterator\Src\SavingIterator
- * 
- * @todo #51:30min It seems that The and Let new typehints have a negative
- *  effect on PHPStan in a way that when type coming to The or Let is not
- *  typehinted as plain `mixed` or `Closure` PHPStan starts complaining about
- *  types for `TransparentIterator` for example. It should probably be solved
- *  by prefixing tags for PHPStan with `phpstan`. It also causes IDE to
- *  complain about incorrect types(X or T or Y instead of some expected type).
  */
 class SavingIteratorTest extends TestCase
 {


### PR DESCRIPTION
This PR solves #64 . PHPStan annotations in `Let` and `The` were changed so that they no longer cause errors.