### PR TITLE
194

### DIFF
--- a/src/SavingIterator.php
+++ b/src/SavingIterator.php
@@ -2,7 +2,9 @@
 
 namespace MaxGoryunov\SavingIterator\Src;
 
+use Closure;
 use Iterator;
+use Generator;
 
 /**
  * Iterator which stores iterated values.
@@ -15,13 +17,13 @@ final class SavingIterator extends IteratorEnvelope
     /**
      * Ctor.
      * 
-     * @phpstan-param Iterator<TKey, TValue>       $origin
+     * @phpstan-param Iterator<TKey, TValue>|Closure():Generator<TKey, TValue, void, void> $origin
      * @phpstan-param AddingIterator<TKey, TValue> $target
-     * @param Iterator       $origin original iterator.
-     * @param AddingIterator $target iterator to which the values are saved.
+     * @param Iterator|Closure $origin original iterator.
+     * @param AddingIterator   $target iterator to which the values are saved.
      */
     public function __construct(
-        Iterator $origin,
+        Iterator|Closure $origin,
         AddingIterator $target
     ) {
         parent::__construct(
@@ -30,7 +32,7 @@ final class SavingIterator extends IteratorEnvelope
                 $target,
                 new ClosureReaction(
                     fn (AddingIterator $stored) => (new ValidTernary(
-                        $origin,
+                        ($origin instanceof Closure) ? $origin() : $origin,
                         function (Iterator $source) use ($stored) {
                             $temp = $stored->from($source);
                             $source->next();

--- a/src/SavingIterator.php
+++ b/src/SavingIterator.php
@@ -26,6 +26,11 @@ final class SavingIterator extends IteratorEnvelope
         Iterator|Closure $origin,
         AddingIterator $target
     ) {
+        /**
+         * @todo #194:15min README has to show that it is now possible to 
+         *  directly pass Generator Closures into constructor without 
+         *  having to manually call them.
+         */
         parent::__construct(
             /** @phpstan-ignore-next-line */
             new ContextVeil(


### PR DESCRIPTION
This PR closes #194 . Now it is possible to pass `Generators` to constructor of `SavingIterator` without having to manually call its `Closure`. 